### PR TITLE
Add option to export left and right part of radiographs separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 
 - `sof-convert-labels` tool to convert proximal femur detection labels from label-studio json format to a short csv format.
+- Options for `sof-export-images` tool to split images into left and right half.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ optional arguments:
 ```text
 usage: sof-export-images [-h] [-V] [--data_dir DATA_DIR]
                          [--configuration CONFIGURATION] [--format {png,jpeg}]
-                         [--width WIDTH] [--height HEIGHT]
+                         [--width WIDTH] [--height HEIGHT] [--split_lr]
+                         [--flip_lr]
                          target_path
 
 Exports the SOF_hip dataset as png images
@@ -65,6 +66,16 @@ optional arguments:
                         Target width of the exported images
   --height HEIGHT, -g HEIGHT
                         Target height of the exported images
+  --split_lr, -s        Split radiographs vertically into a left and a right
+                        half. The exported files will get a "L" or "R"
+                        postfix, depending on the side of the hip that is
+                        shown. Note that the left hip is usually shown on the
+                        right hand side of the radiograph. If the (possibly
+                        downscaled) image does not have an even width, it is
+                        padded with one additional volumn to the right.
+  --flip_lr, -p         Flips the images of the left hip so that they look
+                        like a right hip. Can only be used in combination with
+                        --flip_lr
 ```
 
 ### sof-convert-labels

--- a/bin/sof-export-images
+++ b/bin/sof-export-images
@@ -4,6 +4,7 @@ def main():
     import argparse
     import tensorflow_datasets as tfds
     from sof_utils.export import export_images
+    import sys
 
     parser = argparse.ArgumentParser(description='Exports the SOF_hip dataset as png images')
     parser.add_argument('target_path', type=str,
@@ -20,6 +21,15 @@ def main():
                         help='Target width of the exported images')
     parser.add_argument('--height', '-g', type=int, default=None,
                         help='Target height of the exported images')
+    parser.add_argument('--split_lr', '-s', action='store_true',
+                        help='Split radiographs vertically into a left and a right half. The exported files will get '
+                             'a "L" or "R" postfix, depending on the side of the hip that is shown. Note that the '
+                             'left hip is usually shown on the right hand side of the radiograph. If the (possibly '
+                             'downscaled) image does not have an even width, it is padded with one additional volumn '
+                             'to the right.')
+    parser.add_argument('--flip_lr', '-p', action='store_true',
+                        help='Flips the images of the left hip so that they look like a right hip. Can only be used '
+                             'in combination with --flip_lr')
 
     args = parser.parse_args()
 
@@ -28,12 +38,18 @@ def main():
         print(sof_utils.__version__)
         exit(0)
 
+    if args.flip_lr and not args.split_lr:
+        print("Error: --flip_lr can only be used in combination with --split_lr.\n", file=sys.stderr)
+        parser.print_usage()
+        exit(1)
+
     ds_name = 'SOF_hip' if not args.configuration else f"SOF_hip/{args.configuration}"
     ds = tfds.load(ds_name, split='train', data_dir=args.data_dir if args.data_dir else None)
 
     target_size = (args.height, args.width)
 
-    export_images(ds, args.target_path, format=args.format, downsample_to=target_size)
+    export_images(ds, args.target_path, format=args.format, downsample_to=target_size, split_lr=args.split_lr,
+                  flip_lr=args.flip_lr)
 
 
 if __name__ == '__main__':

--- a/sof_utils/export.py
+++ b/sof_utils/export.py
@@ -6,7 +6,9 @@ import tensorflow as tf
 def export_images(dataset: tf.data.Dataset,
                   target_path: str,
                   format: str = 'png',
-                  downsample_to: Tuple[Union[int, None], Union[int, None]] = (1, None)):
+                  downsample_to: Tuple[Union[int, None], Union[int, None]] = (1, None),
+                  split_lr: bool = False,
+                  flip_lr: bool = False):
     """ Export the given dataset to png images
     :param dataset: Dataset to export
     :param target_path: path where the images will be exported to.
@@ -14,10 +16,17 @@ def export_images(dataset: tf.data.Dataset,
     :param downsample_to: target (width, height) of exported image (defaults to (None, None)).
         If one entry is None, it is inferred from the other one by keeping the aspect ratio.
         If booth entries are None, the original size is kept.
+    :split_lr: if true (default is false), splits the image vertically into a left and a right part, i.e. two instead of
+        one image files are written per example.
+    :flip_lr: if true (default is false), flips the right part of the image vertically. Does nothing if
+        'split_lr == False'.
     """
     from pathlib import Path
     from tqdm import tqdm
     from math import ceil
+
+    target_path = Path(target_path)
+    target_path.mkdir(parents=True, exist_ok=True)
 
     if format.lower() == 'png':
         encoding_func = lambda x: tf.io.encode_png(x)
@@ -39,7 +48,43 @@ def export_images(dataset: tf.data.Dataset,
         downsample_to = (downsample_to[0], int(ceil(ratio * float(image_shape[1]))))
 
     for example in tqdm(dataset):
-        filename = Path(target_path).joinpath(f'{example["id"]}V{example["visit"]}.png')
-        image = tf.cast(tf.image.resize(example['image'], downsample_to), dtype=tf.uint8)
-        encoded_image = encoding_func(image)
-        tf.io.write_file(str(filename), encoded_image)
+        image = tf.cast(tf.image.resize(example['image'], (downsample_to[1], downsample_to[0])), dtype=tf.uint8)
+
+        if split_lr:
+            left_img, right_img = split_image_lr(image, flip_lr)
+            postfix = f"-{left_img.shape[1]}x{left_img.shape[0]}"
+            # write left image, ie.e right hip
+            filename = target_path.joinpath(f'{example["id"]}V{example["visit"]}R{postfix}.png')
+            encoded_image = encoding_func(left_img)
+            tf.io.write_file(str(filename), encoded_image)
+
+            # write right image, i.e. left hip
+            filename = target_path.joinpath(f'{example["id"]}V{example["visit"]}L{postfix}.png')
+            encoded_image = encoding_func(left_img)
+            tf.io.write_file(str(filename), encoded_image)
+        else:
+            postfix = f"-{image.shape[1]}x{image.shape[0]}"
+            filename = target_path.joinpath(f'{example["id"]}V{example["visit"]}{postfix}.png')
+            encoded_image = encoding_func(image)
+            tf.io.write_file(str(filename), encoded_image)
+
+
+def split_image_lr(image: tf.Tensor, flip_lr: bool = False) -> Tuple[tf.Tensor, tf.Tensor]:
+    """ Split image vertically into a left and a right image.
+    If the image does not have an even width, it is padded by one column at the right.
+    :param image: source image to split
+    :param flip_lr: If true, flips the right image vertically.
+    :return: (left_image, right_image) tuple containing the left and the right half of the image.
+    """
+    padding = image.shape[1] % 2
+    padded_image = tf.image.pad_to_bounding_box(image, 0, 0, image.shape[0], image.shape[1] + padding)
+
+    image_half_width = tf.cast(tf.math.ceil(padded_image.shape[1] / 2), tf.int64)
+
+    left_image = padded_image[..., 0:image_half_width, :]
+    right_image = padded_image[..., image_half_width:, :]
+
+    if flip_lr:
+        right_image = tf.image.flip_left_right(right_image)
+
+    return left_image, right_image


### PR DESCRIPTION
This implements #1.
Adds two options to `sot-export-images`:
- `--split_lr` - if set, writes the left and the right parts of an example to different files.
- `--flip_lr` - if set, flips the right image left/right so that is appears like a right hip.
