### PR TITLE
Add support for exporting only specific visits #3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - `sof-convert-labels` tool to convert proximal femur detection labels from label-studio json format to a short csv format.
 - Options for `sof-export-images` tool to split images into left and right half.
+- Option for `sof-export-images` to only export selected visits.
 
 ### Removed
 
@@ -19,7 +20,7 @@
 ### Added
 
 - Tool to export the images from the SOF_hip dataset to PNG or JPG files.
-- Function to extract ID and visit from a filename
+- Function to extract ID and visit from a filename 
 
 ## 0.0.5
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ optional arguments:
 usage: sof-export-images [-h] [-V] [--data_dir DATA_DIR]
                          [--configuration CONFIGURATION] [--format {png,jpeg}]
                          [--width WIDTH] [--height HEIGHT] [--split_lr]
-                         [--flip_lr]
+                         [--flip_lr] [--visits VISITS]
                          target_path
 
 Exports the SOF_hip dataset as png images
@@ -76,6 +76,9 @@ optional arguments:
   --flip_lr, -p         Flips the images of the left hip so that they look
                         like a right hip. Can only be used in combination with
                         --flip_lr
+  --visits VISITS, -v VISITS
+                        Comma separated list of visits to export. If this
+                        option is omitted, all visits are exported.
 ```
 
 ### sof-convert-labels

--- a/bin/sof-export-images
+++ b/bin/sof-export-images
@@ -30,6 +30,9 @@ def main():
     parser.add_argument('--flip_lr', '-p', action='store_true',
                         help='Flips the images of the left hip so that they look like a right hip. Can only be used '
                              'in combination with --flip_lr')
+    parser.add_argument('--visits', '-v', type=str, default=None,
+                        help='Comma separated list of visits to export. If this option is omitted, all visits are '
+                             'exported.')
 
     args = parser.parse_args()
 
@@ -43,13 +46,16 @@ def main():
         parser.print_usage()
         exit(1)
 
+    # Split selected visits of given
+    visits = [int(visit) for visit in args.visits.split(',') if visit] if args.visits else []
+
     ds_name = 'SOF_hip' if not args.configuration else f"SOF_hip/{args.configuration}"
     ds = tfds.load(ds_name, split='train', data_dir=args.data_dir if args.data_dir else None)
 
     target_size = (args.height, args.width)
 
     export_images(ds, args.target_path, format=args.format, downsample_to=target_size, split_lr=args.split_lr,
-                  flip_lr=args.flip_lr)
+                  flip_lr=args.flip_lr, visits=visits)
 
 
 if __name__ == '__main__':

--- a/sof_utils/export.py
+++ b/sof_utils/export.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from typing import Tuple, Union, List
 
 import tensorflow as tf
 
@@ -8,7 +8,8 @@ def export_images(dataset: tf.data.Dataset,
                   format: str = 'png',
                   downsample_to: Tuple[Union[int, None], Union[int, None]] = (1, None),
                   split_lr: bool = False,
-                  flip_lr: bool = False):
+                  flip_lr: bool = False,
+                  visits: List[int] = []):
     """ Export the given dataset to png images
     :param dataset: Dataset to export
     :param target_path: path where the images will be exported to.
@@ -48,6 +49,9 @@ def export_images(dataset: tf.data.Dataset,
         downsample_to = (downsample_to[0], int(ceil(ratio * float(image_shape[1]))))
 
     for example in tqdm(dataset):
+        if visits and example['visit'] not in visits:
+            continue
+
         image = tf.cast(tf.image.resize(example['image'], (downsample_to[1], downsample_to[0])), dtype=tf.uint8)
 
         if split_lr:


### PR DESCRIPTION
This PR Implements #3.

Adds an option to `sof-export-images` to only export selected visits.
Visits can be selected using the '--visits' or '-v' option
e.g. `--visits=1,5` exports only visits 1 and 5.

This closes #3.