### PR TITLE
Add option to include or exclude specific IDs #6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `sof-convert-labels` tool to convert proximal femur detection labels from label-studio json format to a short csv format.
 - Options for `sof-export-images` tool to split images into left and right half.
 - Option for `sof-export-images` to only export selected visits.
+- Option for `sof-export-images` to include or exclude SOF IDs listed in files.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ optional arguments:
 usage: sof-export-images [-h] [-V] [--data_dir DATA_DIR]
                          [--configuration CONFIGURATION] [--format {png,jpeg}]
                          [--width WIDTH] [--height HEIGHT] [--split_lr]
-                         [--flip_lr] [--visits VISITS]
+                         [--flip_lr] [--visits VISITS] [--include INCLUDE]
+                         [--exclude EXCLUDE]
                          target_path
 
 Exports the SOF_hip dataset as png images
@@ -79,6 +80,10 @@ optional arguments:
   --visits VISITS, -v VISITS
                         Comma separated list of visits to export. If this
                         option is omitted, all visits are exported.
+  --include INCLUDE     Only include the IDs listed in given file. The IDs
+                        should be listed one ID per line.
+  --exclude EXCLUDE     Exclude the IDs listed in given file. The IDs should
+                        be listed one ID per line.
 ```
 
 ### sof-convert-labels

--- a/bin/sof-export-images
+++ b/bin/sof-export-images
@@ -1,5 +1,23 @@
 #!/usr/bin/env python
 
+from typing import Union, Set
+
+
+def ids_from_file(filename: Union[None, str]) -> Set[int]:
+    """ Reads IDs from a file line by line and return them as a set of integers.
+    :param filename: Path to file containing IDs
+    :return: set of integer IDs
+    """
+    listed_ids = set()
+    if not filename:
+        return listed_ids
+
+    with open(filename, 'r') as f:
+        for sof_id in f.read().split():
+            listed_ids.add(int(sof_id))
+    return listed_ids
+
+
 def main():
     import argparse
     import tensorflow_datasets as tfds
@@ -33,6 +51,10 @@ def main():
     parser.add_argument('--visits', '-v', type=str, default=None,
                         help='Comma separated list of visits to export. If this option is omitted, all visits are '
                              'exported.')
+    parser.add_argument('--include', type=str, default=None,
+                        help='Only include the IDs listed in given file. The IDs should be listed one ID per line.')
+    parser.add_argument('--exclude', type=str, default=None,
+                        help='Exclude the IDs listed in given file. The IDs should be listed one ID per line.')
 
     args = parser.parse_args()
 
@@ -54,8 +76,12 @@ def main():
 
     target_size = (args.height, args.width)
 
+    included_ids = ids_from_file(args.include)
+    excluded_ids = ids_from_file(args.exclude)
+
     export_images(ds, args.target_path, format=args.format, downsample_to=target_size, split_lr=args.split_lr,
-                  flip_lr=args.flip_lr, visits=visits)
+                  flip_lr=args.flip_lr, visits=visits,
+                  included_ids=included_ids, excluded_ids=excluded_ids)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implements #6

Add options `--include` and `--exclude` to `sof-export-images` to include or exclude specific SOF IDs from the export process.

The files must contain one ID per line.

Closes #6