### PR TITLE
Add zip support #9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Option for `sof-export-images` to only export selected visits.
 - Option for `sof-export-images` to include or exclude SOF IDs listed in files.
 - Options to group the exported images (`--num-groups`, `--max-group-size` and `--randomized-groups`).
+- Option `--zip` for `sof-export-images` to write expoted image directly to (a) zip archive(s).
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ usage: sof-export-images [-h] [-V] [--data_dir DATA_DIR]
                          [--flip_lr] [--visits VISITS] [--include INCLUDE]
                          [--exclude EXCLUDE] [--max-group-size MAX_GROUP_SIZE]
                          [--num-groups NUM_GROUPS] [--randomized-groups]
+                         [--zip]
                          target_path
 
 Exports the SOF_hip dataset as png images
@@ -96,6 +97,11 @@ optional arguments:
   --randomized-groups   If grouping is used (either with --max-group-size or
                         with --num-groups), the assignment of files to groups
                         will be randomized.
+  --zip, -z             Write exported images to a zip file instead of into a
+                        directory. If grouping is enabled, one zip file per
+                        group will be created. Without grouping 'target_path'
+                        should be a path a the target zip file not to an
+                        directoty.
 ```
 
 ### sof-convert-labels

--- a/bin/sof-export-images
+++ b/bin/sof-export-images
@@ -64,6 +64,10 @@ def main():
     parser.add_argument('--randomized-groups', action='store_true',
                         help='If grouping is used (either with --max-group-size or with --num-groups), the assignment '
                              'of files to groups will be randomized.')
+    parser.add_argument('--zip', '-z', action='store_true',
+                        help='Write exported images to a zip file instead of into a directory. If grouping is '
+                             'enabled, one zip file per group will be created. Without grouping \'target_path\' '
+                             'should be a path a the target zip file not to an directoty.')
 
     args = parser.parse_args()
 
@@ -97,7 +101,8 @@ def main():
                   included_ids=included_ids, excluded_ids=excluded_ids,
                   num_groups=args.num_groups,
                   max_group_size=args.max_group_size,
-                  randomized_groups=args.randomized_groups)
+                  randomized_groups=args.randomized_groups,
+                  zip=args.zip)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR implements #9.

Added option `--zip` or `-z`. When this option is used, the exported images are written into a zip archive instead of single files.
If grouping is enabled, one zip archive per group is created.

Closes #9.