### PR TITLE
Add a tool to covert the TFDS dataset into a format supported by the TF ObjectDetection API #11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+
+### Added
+
+- `sof-convert-tfds` tool to convert the TFDS dataset to other formats.
+
 ### Changed
 
 - Adapted `sof-convert-labels` tool to new LabelStudio label format (including key points).

--- a/README.md
+++ b/README.md
@@ -118,3 +118,34 @@ optional arguments:
   -V, --version         Print the version string
   -f FILE, --file FILE  Write output to file instead to stdout
 ```
+
+### sof-convert-tfds
+```text
+usage: sof-convert-tfds [-h] [--data_dir DATA_DIR] [-V]
+                        [--configuration {keypoint_detection}]
+                        [--format {TFObjectDetection}] [--split SPLIT]
+                        [--num_shards NUM_SHARDS]
+                        output_file
+
+Convert SOF_hip TFDS dataset into another format.
+
+positional arguments:
+  output_file           Path to destination file.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --data_dir DATA_DIR   TFDS data dir.
+  -V, --version         Print the version string
+  --configuration {keypoint_detection}, -c {keypoint_detection}
+                        Dataset configuration to use. Note: not all
+                        configuration are supported by all output format.
+                        Default is 'keypoint_detection'
+  --format {TFObjectDetection}, -f {TFObjectDetection}
+                        Dataset configuration to use. Note: not all
+                        configuration are supported by all output format.
+                        Default is 'TFObjectDetection'
+  --split SPLIT, -s SPLIT
+                        Split to convert. Default to 'train'
+  --num_shards NUM_SHARDS, -n NUM_SHARDS
+                        Number of shards to split the resulting dataset into.
+```

--- a/bin/sof-convert-tfds
+++ b/bin/sof-convert-tfds
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+import tensorflow_datasets as tfds
+import SOF_hip
+import tensorflow as tf
+
+
+def convert_example(example):
+    import sof_utils.dataset_utils as utils
+    from hashlib import sha256
+
+    image = example['image']
+    encoded_image = tf.image.encode_png(image=image).numpy()
+    image_key = sha256(encoded_image).hexdigest()
+    bbox = example['object/bbox'].numpy()
+    keypoints = example['object/keypoints'].numpy()
+    keypoints_y = keypoints[..., 0].tolist()
+    keypoints_x = keypoints[..., 1].tolist()
+
+    feature_dict = {
+        'image/height': utils.int64_feature(image.shape[0]),
+        'image/width': utils.int64_feature(image.shape[1]),
+        'image/filename': utils.bytes_feature(example['image/filename'].numpy()),
+        'image/source_id': utils.bytes_feature(
+            f"{example['image/id'].numpy()}V{example['image/visit'].numpy()}{example['image/left_right'].numpy().decode('utf8')}".encode(
+                'utf8')),
+        'image/sha256': utils.bytes_feature(image_key.encode('utf8')),
+        'image/encoded': utils.bytes_feature(encoded_image),
+        'image/format': utils.bytes_feature("png".encode('utf8')),
+        'image/object/bbox/ymin': utils.float_list_feature([bbox[0]]),
+        'image/object/bbox/xmin': utils.float_list_feature([bbox[1]]),
+        'image/object/bbox/ymax': utils.float_list_feature([bbox[2]]),
+        'image/object/bbox/xmax': utils.float_list_feature([bbox[3]]),
+        'image/object/keypoint/y': utils.float_list_feature(keypoints_y),
+        'image/object/keypoint/x': utils.float_list_feature(keypoints_x)
+    }
+
+    return tf.train.Example(features=tf.train.Features(feature=feature_dict))
+
+
+def convert_to_TFObjectDetection(ds, out_file, num_shards=1):
+    from tqdm import tqdm
+    import contextlib2
+    from sof_utils import tf_record_creation_util
+
+    with contextlib2.ExitStack() as tf_record_close_stack:
+        output_tfrecords = tf_record_creation_util.open_sharded_output_tfrecords(
+            tf_record_close_stack, out_file, num_shards)
+        for idx, example in tqdm(enumerate(ds), unit=' examples', desc='Converting dataset'):
+            converted_example = convert_example(example)
+            shard_idx = idx % num_shards
+            output_tfrecords[shard_idx].write(converted_example.SerializeToString())
+
+
+def main():
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description='Convert SOF_hip TFDS dataset into another format.')
+    parser.add_argument('output_file', type=str,
+                        help='Path to destination file.')
+    parser.add_argument('--data_dir', type=str,
+                        help='TFDS data dir.')
+    parser.add_argument('-V', '--version', action='store_true',
+                        help="Print the version string")
+    parser.add_argument('--configuration', '-c', type=str, default='keypoint_detection',
+                        choices=['keypoint_detection'],
+                        help='Dataset configuration to use. Note: not all configuration are supported by all output format. Default is \'keypoint_detection\'')
+    parser.add_argument('--format', '-f', type=str, default='TFObjectDetection',
+                        choices=['TFObjectDetection'],
+                        help='Dataset configuration to use. Note: not all configuration are supported by all output format. Default is \'TFObjectDetection\'')
+    parser.add_argument('--split', '-s', type=str, default='train',
+                        help='Split to convert. Default to \'train\'')
+    parser.add_argument('--num_shards', '-n', type=int, default=1,
+                        help='Number of shards to split the resulting dataset into.')
+
+    args = parser.parse_args()
+
+    if args.version:
+        import sof_utils
+        print(sof_utils.__version__)
+        exit(0)
+
+    ds = tfds.load(f"SOF_hip/{args.configuration}", data_dir=args.data_dir)[args.split]
+
+    if args.format == 'TFObjectDetection':
+        convert_to_TFObjectDetection(ds, args.output_file, args.num_shards)
+    else:
+        print(f"Error: Unknown format: {args.format}", file=sys.stderr)
+        exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,9 @@ setuptools.setup(
     scripts=[
         'bin/sof-dicom-meta',
         'bin/sof-dicom-corrupted',
-        'bin/sof-export-images'
+        'bin/sof-export-images',
+        'bin/sof-convert-labels',
+        'bin/sof-convert-tfds'
     ],
     install_requires=requirements
 )

--- a/sof_utils/dataset_utils.py
+++ b/sof_utils/dataset_utils.py
@@ -1,0 +1,24 @@
+import tensorflow as tf
+
+def int64_feature(value):
+  return tf.train.Feature(int64_list=tf.train.Int64List(value=[value]))
+
+
+def int64_list_feature(value):
+  return tf.train.Feature(int64_list=tf.train.Int64List(value=value))
+
+
+def bytes_feature(value):
+  return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value]))
+
+
+def bytes_list_feature(value):
+  return tf.train.Feature(bytes_list=tf.train.BytesList(value=value))
+
+
+def float_feature(value):
+  return tf.train.Feature(float_list=tf.train.FloatList(value=[value]))
+
+
+def float_list_feature(value):
+  return tf.train.Feature(float_list=tf.train.FloatList(value=value))

--- a/sof_utils/misc.py
+++ b/sof_utils/misc.py
@@ -72,7 +72,7 @@ def read_label_file(filename: str) -> List[Dict]:
                 'left_right': lr,
                 'upside_down': upside_down,
                 'incomplete': incomplete,
-                'implant': incomplete,
+                'implant': implant,
                 'width': width,
                 'height': height
             }

--- a/sof_utils/tf_record_creation_util.py
+++ b/sof_utils/tf_record_creation_util.py
@@ -1,0 +1,42 @@
+# Lint as: python2, python3
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+r"""Utilities for creating TFRecords of TF examples for the Open Images dataset.
+"""
+
+import tensorflow as tf
+
+
+def open_sharded_output_tfrecords(exit_stack, base_path, num_shards):
+    """Opens all TFRecord shards for writing and adds them to an exit stack.
+    Args:
+      exit_stack: A context2.ExitStack used to automatically closed the TFRecords
+        opened in this function.
+      base_path: The base path for all shards
+      num_shards: The number of shards
+    Returns:
+      The list of opened TFRecords. Position k in the list corresponds to shard k.
+    """
+    tf_record_output_filenames = [
+        '{}-{:05d}-of-{:05d}'.format(base_path, idx, num_shards)
+        for idx in range(num_shards)
+    ]
+
+    tfrecords = [
+        exit_stack.enter_context(tf.io.TFRecordWriter(file_name))
+        for file_name in tf_record_output_filenames
+    ]
+
+    return tfrecords


### PR DESCRIPTION
This PR implements #11.
A new tool `sof-convert-tfds` is added that converts the TFDS SOF_hip dataset to other formats.

Currently only the `keypoint_detection` configuration is supported.
Currently, the only available format is `TFObjectDetection` that results in a (possible shared) .tfrecord file that can be used with the TF object detection API.

Closes #11.